### PR TITLE
Added a `system` property to prevent `Unrecognized field "system"` when calling `OllamaApi.getModelDetails`

### DIFF
--- a/src/main/java/io/github/amithkoujalgi/ollama4j/core/models/ModelDetail.java
+++ b/src/main/java/io/github/amithkoujalgi/ollama4j/core/models/ModelDetail.java
@@ -7,6 +7,15 @@ public class ModelDetail {
     @JsonProperty("modelfile")
     private String modelFile;
     private String parameters, template;
+    private String system;
+
+    public String getSystem() {
+        return system;
+    }
+
+    public void setSystem(String system) {
+        this.system = system;
+    }
 
     public String getLicense() {
         return license;


### PR DESCRIPTION
For some models, calling `OllamaApi.getModelDetails` could result in `UnrecognizedPropertyException` being thrown because these models define a `system` property in their modelfiles but the `ModelDetails` class doesn't have a corresponding field.

The following is a stack trace from calling `OllamaApi.getModelDetails("samantha-mistral")`:

```
com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "system" (class io.github.amithkoujalgi.ollama4j.core.models.ModelDetail), not marked as ignorable (4 known properties: "license", "parameters", "modelfile", "template"])
 at [Source: (String)"{"modelfile":"# Modelfile generated by \"ollama show\"\n# To build a new Modelfile based on this one, replace the FROM line with:\n# FROM samantha-mistral:latest\n\nFROM /data/models/cache/ollama/blobs/sha256:4a3019290402c9eadf89a3bf793102a52a2a44dd76ea7b07fca53f9cbb789a63\nTEMPLATE \"\"\"\u003c|im_start|\u003esystem\n{{ .System }}\u003c|im_end|\u003e\n\u003c|im_start|\u003euser\n{{ .Prompt }}\u003c|im_end|\u003e\n\u003c|im_start|\u003eassistant\n\n\"\"\"\nSYSTEM \"\"\"You are a caring and empat"[truncated 519 chars]; line: 1, column: 947] (through reference chain: io.github.amithkoujalgi.ollama4j.core.models.ModelDetail["system"])
        at com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException.from(UnrecognizedPropertyException.java:61)
        at com.fasterxml.jackson.databind.DeserializationContext.handleUnknownProperty(DeserializationContext.java:1138)
        at com.fasterxml.jackson.databind.deser.std.StdDeserializer.handleUnknownProperty(StdDeserializer.java:2224)
        at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.handleUnknownProperty(BeanDeserializerBase.java:1709)
        at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.handleUnknownVanilla(BeanDeserializerBase.java:1687)
        at com.fasterxml.jackson.databind.deser.BeanDeserializer.vanillaDeserialize(BeanDeserializer.java:320)
        at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:177)
        at com.fasterxml.jackson.databind.deser.DefaultDeserializationContext.readRootValue(DefaultDeserializationContext.java:323)
        at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:4825)
        at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3772)
        at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3740)
        at io.github.amithkoujalgi.ollama4j.core.OllamaAPI.getModelDetails(OllamaAPI.java:118)
```

This PR adds a `system` field to `ModelDetail` class along with getters and setters.