### PR TITLE
Correction of Documentation for ask-async

### DIFF
--- a/docs/docs/apis-ask/ask-async.md
+++ b/docs/docs/apis-ask/ask-async.md
@@ -24,8 +24,8 @@ public class Main {
         while (!callback.isComplete() || !callback.getStream().isEmpty()) {
             // poll for data from the response stream
             String result = callback.getStream().poll();
-            if (response != null) {
-                System.out.print(result.getResponse());
+            if (result != null) {
+                System.out.print(result);
             }
             Thread.sleep(100);
         }


### PR DESCRIPTION
The ask-async documentation is not working anymore. This fixes the docs to be executable with version 1.0.47