### PR TITLE
Adds model property to Model Type

### DIFF
--- a/src/main/java/io/github/amithkoujalgi/ollama4j/core/models/Model.java
+++ b/src/main/java/io/github/amithkoujalgi/ollama4j/core/models/Model.java
@@ -7,6 +7,7 @@ import lombok.Data;
 public class Model {
 
   private String name;
+  private String model;
   @JsonProperty("modified_at")
   private String modifiedAt;
   private String digest;


### PR DESCRIPTION
As of  ollama version v.0.1.24, the Model Response type has added the model property to its ModelType:

``` go
type ModelResponse struct {
	Name       string       `json:"name"`
	Model      string       `json:"model"`
	ModifiedAt time.Time    `json:"modified_at"`
	Size       int64        `json:"size"`
	Digest     string       `json:"digest"`
	Details    ModelDetails `json:"details,omitempty"`
}
```

Thus the Representation of the Model Type in ollama4j should provide this property as well.