### PR TITLE
docs: Update ollama4j examples in README to version 1.1.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ In your Maven project, add this dependency:
 <dependency>
     <groupId>io.github.ollama4j</groupId>
     <artifactId>ollama4j</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.6</version>
 </dependency>
 ```
 
@@ -198,7 +198,7 @@ In your Maven project, add this dependency:
 <dependency>
     <groupId>io.github.ollama4j</groupId>
     <artifactId>ollama4j</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.6</version>
 </dependency>
 ```
 
@@ -208,7 +208,7 @@ In your Maven project, add this dependency:
 
 ```groovy
 dependencies {
-    implementation 'io.github.ollama4j:ollama4j:1.1.0'
+    implementation 'io.github.ollama4j:ollama4j:1.1.6'
 }
 ```
 


### PR DESCRIPTION
## Description

Update `README.md` dependency snippets to use **ollama4j version 1.1.6**, replacing the outdated `1.1.0`.

This change applies to:
- Both Maven examples
- The Gradle example

**Reasoning:**
Version `1.1.0` contains API signatures and function names that differ significantly from `1.1.6`. Keeping the old version in the documentation causes confusion and build errors for developers who copy-paste the examples while following the latest codebase or documentation logic. This update ensures the getting-started guide aligns with the current stable API.

## Type of change

- [ ] feat: New feature
- [ ] fix: Bug fix
- [x] docs: Documentation update
- [ ] refactor: Refactoring
- [ ] test: Tests only
- [ ] build/ci: Build or CI changes

## How has this been tested?


## Checklist

- [x] I ran `pre-commit run -a` locally
- [x] `make build` succeeds locally
- [x] Unit/integration tests added or updated as needed (N/A for docs-only change)
- [x] Docs updated (README/docs site) if user-facing changes
- [x] PR title follows Conventional Commits

## Breaking changes

None. This change only affects the documentation snippets. However, it prevents a potential "breaking experience" for new users who would otherwise import an incompatible version (`1.1.0`) and encounter compilation errors when following the guide.

## Related issues

Fixes #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated dependency version examples to 1.1.6 in usage guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->