### PR TITLE
Add `OllamaChatRequest.withFormat(Map<String, Object> format)`

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,9 +374,9 @@ Ollama4j has been featured in a number of articles and community posts—huge th
 
 - **Running LLM locally using Java** — [Article by Stephan Janssen (LinkedIn)](https://www.linkedin.com/pulse/running-llm-locally-using-java-stephan-janssen-g4mue)
 - **Java library announcement** — [Post by Markus Klenke (LinkedIn)](https://www.linkedin.com/posts/markus-klenke-61041086_github-amithkoujalgiollama4j-java-library-activity-7166431630939639808-JyEH)
-- **Tame Your Llama: Run AI in Java**  
-  - 🎤 [JNation Talk: Presented by Lutske de Leeuw](https://youtu.be/XvmGqpzepDM?t=966)  
-  - 📝 [In-depth Forum Article](https://javapro.io/2025/10/15/tame-your-llama-run-ai-in-java/)  
+- **Tame Your Llama: Run AI in Java**
+  - 🎤 [JNation Talk: Presented by Lutske de Leeuw](https://youtu.be/XvmGqpzepDM?t=966)
+  - 📝 [In-depth Forum Article](https://javapro.io/2025/10/15/tame-your-llama-run-ai-in-java/)
   - 🐦 [Announcement on X (Twitter)](https://x.com/JAVAPROmagazin/status/1978347624265646211)
 - **First Conversation with Deepseek Model** — [Post by Ghaffar Mallah (LinkedIn)](https://www.linkedin.com/posts/ghaffarmallah_ok-ai-i-finally-see-you-with-deepseek-hype-activity-7290019964533526529-G5cq)
 - **From Llamas to Lightsabers: AI in Java** — [Post by Lutske (LinkedIn)](https://www.linkedin.com/posts/lutske_utrechtjug-tameyourllama-java-activity-7386315122748706816-6A_j)

--- a/docs/docs/apis-extras/logging.md
+++ b/docs/docs/apis-extras/logging.md
@@ -14,7 +14,7 @@ Add a `logback.xml` file to your `src/main/resources` folder with the following 
     <root level="DEBUG">
         <appender-ref ref="STDOUT"/>
     </root>
-    
+
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5level %logger{36} - %msg%n</pattern>

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -60,7 +60,7 @@ h2 > a {
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
     background-clip: text;
-    color: transparent; 
+    color: transparent;
 }
 
 .hero__subtitle {
@@ -73,7 +73,7 @@ h2 > a {
     font-weight: bold;
     border-radius: 0px;
     padding: 5px;
-}   
+}
 
 .feature-image {
     max-width: 80px !important;

--- a/src/main/java/io/github/ollama4j/models/chat/OllamaChatRequest.java
+++ b/src/main/java/io/github/ollama4j/models/chat/OllamaChatRequest.java
@@ -18,6 +18,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -130,6 +131,11 @@ public class OllamaChatRequest extends OllamaCommonRequest implements OllamaRequ
 
     public OllamaChatRequest withGetJsonResponse() {
         this.setFormat("json");
+        return this;
+    }
+
+    public OllamaChatRequest withFormat(Map<String, Object> format) {
+        this.setFormat(format);
         return this;
     }
 

--- a/src/test/java/io/github/ollama4j/unittests/models/chat/TestOllamaChatRequest.java
+++ b/src/test/java/io/github/ollama4j/unittests/models/chat/TestOllamaChatRequest.java
@@ -20,6 +20,7 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -61,6 +62,14 @@ class TestOllamaChatRequest {
         assertEquals(ThinkMode.ENABLED, request.getThink());
         assertTrue(request.isUseTools());
         assertEquals("json", request.getFormat());
+    }
+
+    @Test
+    void testWithFormat() {
+        OllamaChatRequest request = new OllamaChatRequest();
+        Map<String, Object> format = Map.of("type", "object");
+        request.withFormat(format);
+        assertEquals(format, request.getFormat());
     }
 
     @Test

--- a/src/test/java/io/github/ollama4j/unittests/models/generate/TestOllamaGenerateRequest.java
+++ b/src/test/java/io/github/ollama4j/unittests/models/generate/TestOllamaGenerateRequest.java
@@ -19,6 +19,7 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -69,6 +70,14 @@ class TestOllamaGenerateRequest {
         assertEquals(ThinkMode.ENABLED, request.getThink());
         assertTrue(request.isUseTools());
         assertEquals("json", request.getFormat());
+    }
+
+    @Test
+    void testWithFormat() {
+        OllamaGenerateRequest request = new OllamaGenerateRequest();
+        Map<String, Object> format = Map.of("type", "object");
+        request.withFormat(format);
+        assertEquals(format, request.getFormat());
     }
 
     @Test


### PR DESCRIPTION
## Description

This PR adds the `OllamaChatRequest.withFormat(Map<String, Object> format)` builder method.

## Type of change

- [ ] feat: New feature
- [ ] fix: Bug fix
- [ ] docs: Documentation update
- [x] refactor: Refactoring
- [ ] test: Tests only
- [ ] build/ci: Build or CI changes

## How has this been tested?

Added serialization test & run all tests.

## Checklist

- [x] I ran `pre-commit run -a` locally
- [x] `make build` succeeds locally
- [x] Unit/integration tests added or updated as needed
- [ ] Docs updated (README/docs site) if user-facing changes
- [ ] PR title follows Conventional Commits

## Breaking changes

List any breaking changes and migration notes.

## Related issues

Fixes #




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a fluent builder method for format configuration in chat requests.

* **Tests**
  * Added test coverage for the new format builder method.

* **Documentation**
  * Normalized markdown formatting in README.
  * Updated documentation formatting for consistency.

* **Style**
  * Removed trailing whitespace from stylesheets and documentation files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->