### PR TITLE
feat: expose model_info in ModelDetail (closes #301)

### DIFF
--- a/src/main/java/io/github/ollama4j/models/response/ModelDetail.java
+++ b/src/main/java/io/github/ollama4j/models/response/ModelDetail.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.github.ollama4j.utils.Utils;
 import lombok.Data;
+import java.util.Map;
 
 @Data
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/io/github/ollama4j/models/response/ModelDetail.java
+++ b/src/main/java/io/github/ollama4j/models/response/ModelDetail.java
@@ -28,6 +28,8 @@ public class ModelDetail {
     private String system;
     private ModelMeta details;
     private String[] capabilities;
+    @JsonProperty("model_info")
+    private Map<String, Object> modelInfo;
 
     @Override
     public String toString() {

--- a/src/main/java/io/github/ollama4j/models/response/ModelDetail.java
+++ b/src/main/java/io/github/ollama4j/models/response/ModelDetail.java
@@ -19,15 +19,18 @@ import java.util.Map;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ModelDetail {
     private String license;
-
     @JsonProperty("modelfile")
     private String modelFile;
-
     private String parameters;
     private String template;
     private String system;
     private ModelMeta details;
     private String[] capabilities;
+    /**
+     * Dynamic model metadata returned by the Ollama API.
+     * Values may be of type {@code String}, {@code Number}, {@code Boolean},
+     * or nested {@code Map}/{@code List}. Cast accordingly after retrieval.
+     */
     @JsonProperty("model_info")
     private Map<String, Object> modelInfo;
 


### PR DESCRIPTION
## Description
Adds `model_info` as `Map<String, Object>` to `ModelDetail` with `@JsonProperty("model_info")` for proper JSON deserialization.

This allows querying model metadata such as context_length, embedding_length, and architecture info via `getModelDetails()` without manually parsing the `/api/show` endpoint.

## Type of change
- [x] feat: New feature

## How has this been tested?
Manually verified JSON deserialization of the model_info field using the example payload from issue #301. The field correctly maps dynamic keys such as context_length, embedding_length, and general.architecture.

## Checklist
- [ ] I ran `pre-commit run -a` locally
- [ ] `make build` succeeds locally
- [x] Unit/integration tests added or updated as needed
- [x] PR title follows Conventional Commits

## Breaking changes
None. Additive change only. Existing fields unmodified.

## Related issues
Fixes #301


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Model detail responses now include additional model information accessible through an enhanced response structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->